### PR TITLE
Better error messages for invalid interfaces.

### DIFF
--- a/source/WcfClientProxyGenerator.Tests/ProxyTests.cs
+++ b/source/WcfClientProxyGenerator.Tests/ProxyTests.cs
@@ -244,5 +244,50 @@ namespace WcfClientProxyGenerator.Tests
         }
 
         #endregion
+
+        #region Better error messages tests
+        [ServiceContract]
+        private interface IPrivateTestService
+        {
+            [OperationContract]
+            void TestMethod();
+        }
+
+        public interface INonServiceInterface
+        {
+            [OperationContract]
+            void TestMethod();
+        }
+
+        [ServiceContract]
+        public interface INoOperationsInterface
+        {
+            void NonOperationTestMethod();
+        }
+
+        [Test]
+        public void Proxy_GivesProperException_IfInterfaceNotPublic()
+        {
+            var mockService = new Mock<IPrivateTestService>();
+            Assert.Throws<InvalidOperationException>(delegate { WcfClientProxy.Create<IPrivateTestService>(); });
+            // error message not checked here, but it should be quite readable
+        }
+
+        [Test]
+        public void Proxy_GivesProperException_IfNotServiceContract()
+        {
+            var mockService = new Mock<INonServiceInterface>();
+            Assert.Throws<InvalidOperationException>(delegate { WcfClientProxy.Create<INonServiceInterface>(); });
+            // error message not checked here, but it should be quite readable
+        }
+
+        [Test]
+        public void Proxy_GivesProperException_IfZeroOperationContracts()
+        {
+            var mockService = new Mock<INoOperationsInterface>();
+            Assert.Throws<InvalidOperationException>(delegate { WcfClientProxy.Create<INoOperationsInterface>(); });
+            // error message not checked here, but it should be quite readable
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Now throws InvalidOperationException if the given service interface:
- Is not marked public
- Is not marked with ServiceContract attribute
- Does not contain methods marked with OperationContract
  The error messages are much easier to understand now.

For example attempting to use an interface without any OperationContract methods before this patch:

```
System.TypeLoadException : Method 'NonOperationTestMethod' in type 'WcfClientProxyGenerator.DynamicProxy.INoOperationsInterface' from assembly 'WcfClientProxyGenerator.DynamicProxy, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.
```

And with this patch:

```
System.InvalidOperationException : Service interface INoOperationsInterface has no OperationContact methods. Is this a proper WCF service interface?
```
