### PR TITLE
Support for working with InstanceContext for duplex channels

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,5 +1,5 @@
 ---
 :major: 2
-:minor: 1
-:patch: 3
+:minor: 2
+:patch: 1
 :special: ''

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Then you can specify the instance context which holds the implementation of your
 	}
 	
 	var receiver = new TestReceiver();
-	vat ctx = new InstanceContext(receiver);
+	vat ctx = new InstanceContext<ICallbackContract>(receiver);
     var proxy = WcfClientProxy.Create<IServiceWithCallback>(c =>
     {
         c.SetEndpoint(binding, endpointAddress, ctx);

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This is a shortcut to using the overload that accepts an `Action<IRetryingProxyC
 #### WcfClientProxy.Create\<TServiceInterface\>(Action\<IRetryingProxyConfigurator\> config)
 Exposes the full configuration available. See the [Configuration](#configuration) section of the documentation.
 #### Duplex Proxy
-To create a duplex proxy, you must use the last factory method `Create\<TServiceInterface\>(Action\<IRetryingProxyConfigurator\> config)` from above. 
+To create a duplex proxy, you must use the last factory method `Create<TServiceInterface>(Action<IRetryingProxyConfigurator> config)` from above. 
 
 Then you can specify the instance context which holds the implementation of your callback receiver.
 	
@@ -107,8 +107,14 @@ Then you can specify the instance context which holds the implementation of your
 	vat ctx = new InstanceContext(receiver);
     var proxy = WcfClientProxy.Create<IServiceWithCallback>(c =>
     {
-        c.SetEndpoint(ctx, binding, endpointAddress);
+        c.SetEndpoint(binding, endpointAddress, ctx);
     });
+	
+	var receiver = new TestReceiver();
+    var proxy = WcfClientProxy.Create<IServiceWithCallback>(c =>
+    {
+        c.SetEndpoint(binding, endpointAddress, receiver);
+    });	
 
 Async Support
 -------------

--- a/README.md
+++ b/README.md
@@ -80,6 +80,35 @@ This is a shortcut to using the overload that accepts an `Action<IRetryingProxyC
 
 #### WcfClientProxy.Create\<TServiceInterface\>(Action\<IRetryingProxyConfigurator\> config)
 Exposes the full configuration available. See the [Configuration](#configuration) section of the documentation.
+#### Duplex Proxy
+To create a duplex proxy, you must use the last factory method `Create\<TServiceInterface\>(Action\<IRetryingProxyConfigurator\> config)` from above. 
+
+Then you can specify the instance context which holds the implementation of your callback receiver.
+	
+	[ServiceContract(CallbackContract = typeof(ITestCallback))]
+	public interface IServiceWithCallback
+	{
+	}
+	
+	public interface ICallbackContract
+    {
+        [OperationContract]
+        void OnCallback(string data);
+    }
+	
+	public class TestReceiver : ICallbackContract
+	{
+		public void OnCallback(string data)
+        {
+        }		
+	}
+	
+	var receiver = new TestReceiver();
+	vat ctx = new InstanceContext(receiver);
+    var proxy = WcfClientProxy.Create<IServiceWithCallback>(c =>
+    {
+        c.SetEndpoint(ctx, binding, endpointAddress);
+    });
 
 Async Support
 -------------

--- a/source/WcfClientProxyGenerator.Tests/DuplexProxyTests.cs
+++ b/source/WcfClientProxyGenerator.Tests/DuplexProxyTests.cs
@@ -77,7 +77,7 @@ namespace WcfClientProxyGenerator.Tests
                     resetEvent.Set();
                 });
 
-            InstanceContext ctx = new InstanceContext(callback);
+            InstanceContext<IDuplexServiceCallback> ctx = new InstanceContext<IDuplexServiceCallback>(callback.Object);
             var proxy = WcfClientProxy.Create<IDuplexService>(c =>
             {
                 c.SetEndpoint(serviceHost.Binding, serviceHost.EndpointAddress, ctx);

--- a/source/WcfClientProxyGenerator/ChannelFactoryProvider.cs
+++ b/source/WcfClientProxyGenerator/ChannelFactoryProvider.cs
@@ -59,11 +59,34 @@ namespace WcfClientProxyGenerator
             return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(callbackObject, binding, endpointAddress));
         }
 
+        public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(Binding binding, EndpointAddress endpointAddress, InstanceContext instanceContext)
+            where TServiceInterface : class
+        {
+            object callbackObject = instanceContext.GetServiceInstance();
+            string cacheKey = GetCacheKey<TServiceInterface>(binding, endpointAddress, callbackObject.GetType());
+            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(instanceContext, binding, endpointAddress));
+        }
+
         public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(ServiceEndpoint endpoint)
             where TServiceInterface : class
         {
             string cacheKey = GetCacheKey<TServiceInterface>(endpoint);
             return GetChannelFactory(cacheKey, () => new ChannelFactory<TServiceInterface>(endpoint));
+        }
+
+         public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(ServiceEndpoint endpoint, object callbackObject)
+            where TServiceInterface : class
+        {
+            string cacheKey = GetCacheKey<TServiceInterface>(endpoint, callbackObject.GetType());
+            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(callbackObject, endpoint));
+        }
+
+           public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(ServiceEndpoint endpoint, InstanceContext instanceContext)
+            where TServiceInterface : class
+        {
+            object callbackObject = instanceContext.GetServiceInstance();
+            string cacheKey = GetCacheKey<TServiceInterface>(endpoint, callbackObject.GetType());
+            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(callbackObject, endpoint));
         }
 
         private static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(string cacheKey, Func<ChannelFactory<TServiceInterface>> factory)
@@ -100,6 +123,12 @@ namespace WcfClientProxyGenerator
         private static string GetCacheKey<TServiceInterface>(ServiceEndpoint endpoint)
         {
             return GetCacheKey<TServiceInterface>(endpoint.Binding, endpoint.Address);
+        }
+
+         private static string GetCacheKey<TServiceInterface>(ServiceEndpoint endpoint, Type callbackType)
+        {
+            string nonDuplexKey = GetCacheKey<TServiceInterface>(endpoint);
+            return nonDuplexKey + $";callback:{callbackType.FullName}";
         }
 
         private static ServiceEndpoint GetClientEndpointConfiguration(

--- a/source/WcfClientProxyGenerator/ChannelFactoryProvider.cs
+++ b/source/WcfClientProxyGenerator/ChannelFactoryProvider.cs
@@ -59,12 +59,11 @@ namespace WcfClientProxyGenerator
             return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(callbackObject, binding, endpointAddress));
         }
 
-        public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(Binding binding, EndpointAddress endpointAddress, InstanceContext instanceContext)
+        public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface, TCallback>(Binding binding, EndpointAddress endpointAddress, InstanceContext<TCallback> instanceContext)
             where TServiceInterface : class
         {
-            object callbackObject = instanceContext.GetServiceInstance();
-            string cacheKey = GetCacheKey<TServiceInterface>(binding, endpointAddress, callbackObject.GetType());
-            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(instanceContext, binding, endpointAddress));
+            string cacheKey = GetCacheKey<TServiceInterface>(binding, endpointAddress, typeof(TCallback));
+            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(instanceContext.Context, binding, endpointAddress));
         }
 
         public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(ServiceEndpoint endpoint)
@@ -81,12 +80,11 @@ namespace WcfClientProxyGenerator
             return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(callbackObject, endpoint));
         }
 
-           public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(ServiceEndpoint endpoint, InstanceContext instanceContext)
+           public static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface, TCallback>(ServiceEndpoint endpoint, InstanceContext<TCallback> instanceContext)
             where TServiceInterface : class
         {
-            object callbackObject = instanceContext.GetServiceInstance();
-            string cacheKey = GetCacheKey<TServiceInterface>(endpoint, callbackObject.GetType());
-            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(callbackObject, endpoint));
+            string cacheKey = GetCacheKey<TServiceInterface>(endpoint, typeof(TCallback));
+            return GetChannelFactory(cacheKey, () => new DuplexChannelFactory<TServiceInterface>(instanceContext.Context, endpoint));
         }
 
         private static ChannelFactory<TServiceInterface> GetChannelFactory<TServiceInterface>(string cacheKey, Func<ChannelFactory<TServiceInterface>> factory)

--- a/source/WcfClientProxyGenerator/IProxyConfigurator.cs
+++ b/source/WcfClientProxyGenerator/IProxyConfigurator.cs
@@ -42,7 +42,7 @@ namespace WcfClientProxyGenerator
         /// <param name="binding"></param>
         /// <param name="endpointAddress"></param>
         /// <param name="instanceContext"></param>
-        void SetEndpoint(Binding binding, EndpointAddress endpointAddress, InstanceContext instanceContext);
+        void SetEndpoint<TCallback>(Binding binding, EndpointAddress endpointAddress, InstanceContext<TCallback> instanceContext);
 
         /// <summary>
         /// Specifies the endpoint configuration to use.
@@ -55,7 +55,7 @@ namespace WcfClientProxyGenerator
         /// </summary>
         /// <param name="endpoint"></param>
         /// <param name="instanceContext"></param>
-        void SetEndpoint(ServiceEndpoint endpoint, InstanceContext instanceContext);
+        void SetEndpoint<TCallback>(ServiceEndpoint endpoint, InstanceContext<TCallback> instanceContext);
 
         /// <summary>
         /// Event that is fired immediately before the service method will be called. This event

--- a/source/WcfClientProxyGenerator/IProxyConfigurator.cs
+++ b/source/WcfClientProxyGenerator/IProxyConfigurator.cs
@@ -37,10 +37,25 @@ namespace WcfClientProxyGenerator
         void SetEndpoint(Binding binding, EndpointAddress endpointAddress, object callbackInstance);
 
         /// <summary>
+        /// Specifies the binding, address to use and callbackInstance to use with DuplexChannel
+        /// </summary>
+        /// <param name="binding"></param>
+        /// <param name="endpointAddress"></param>
+        /// <param name="instanceContext"></param>
+        void SetEndpoint(Binding binding, EndpointAddress endpointAddress, InstanceContext instanceContext);
+
+        /// <summary>
         /// Specifies the endpoint configuration to use.
         /// </summary>
         /// <param name="endpoint"></param>
         void SetEndpoint(ServiceEndpoint endpoint);
+
+        /// <summary>
+        /// Specifies the endpoint configuration to use.
+        /// </summary>
+        /// <param name="endpoint"></param>
+        /// <param name="instanceContext"></param>
+        void SetEndpoint(ServiceEndpoint endpoint, InstanceContext instanceContext);
 
         /// <summary>
         /// Event that is fired immediately before the service method will be called. This event

--- a/source/WcfClientProxyGenerator/InstanceContext.cs
+++ b/source/WcfClientProxyGenerator/InstanceContext.cs
@@ -1,0 +1,41 @@
+﻿using System.ServiceModel;
+
+namespace WcfClientProxyGenerator
+{
+
+    /// <summary>
+    /// Generic instance context for callback services.
+    /// </summary>
+    /// <typeparam name="TCallback">the type of the callback context.</typeparam>
+    public class InstanceContext<TCallback>
+    {
+        private readonly InstanceContext _context;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="callbackInstance"></param>
+        public InstanceContext(TCallback callbackInstance)
+        {
+            _context = new InstanceContext(callbackInstance);
+        }
+
+        /// <summary>
+        /// Get the instance context.
+        /// </summary>
+        public InstanceContext Context => _context;
+
+        /// <summary>
+        /// Gets the service instance.
+        /// </summary>
+        public TCallback ServiceInstance => (TCallback)_context.GetServiceInstance();
+
+        /// <summary>
+        /// Releases the underlying service instance.
+        /// </summary>
+        public void ReleaseServiceInstance()
+        {
+            _context.ReleaseServiceInstance();
+        }
+    }
+}

--- a/source/WcfClientProxyGenerator/RetryingWcfActionInvokerProvider.cs
+++ b/source/WcfClientProxyGenerator/RetryingWcfActionInvokerProvider.cs
@@ -355,9 +355,9 @@ namespace WcfClientProxyGenerator
             channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(binding, endpointAddress, callbackObject);
         }
 
-        public void SetEndpoint(Binding binding, EndpointAddress endpointAddress, InstanceContext instanceContext)
+        public void SetEndpoint<TCallback>(Binding binding, EndpointAddress endpointAddress, InstanceContext<TCallback> instanceContext)
         {
-            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(binding, endpointAddress, instanceContext);
+            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface, TCallback>(binding, endpointAddress, instanceContext);
         }
 
         public void SetEndpoint(ServiceEndpoint endpoint)
@@ -370,9 +370,9 @@ namespace WcfClientProxyGenerator
             channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(endpoint, callbackObject);
         }
 
-        public void SetEndpoint(ServiceEndpoint endpoint, InstanceContext instanceContext)
+        public void SetEndpoint<TCallback>(ServiceEndpoint endpoint, InstanceContext<TCallback> instanceContext)
         {
-            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(endpoint, instanceContext);
+            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface, TCallback>(endpoint, instanceContext);
         }
 
         public void MaximumRetries(int retryCount)

--- a/source/WcfClientProxyGenerator/RetryingWcfActionInvokerProvider.cs
+++ b/source/WcfClientProxyGenerator/RetryingWcfActionInvokerProvider.cs
@@ -355,9 +355,24 @@ namespace WcfClientProxyGenerator
             channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(binding, endpointAddress, callbackObject);
         }
 
+        public void SetEndpoint(Binding binding, EndpointAddress endpointAddress, InstanceContext instanceContext)
+        {
+            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(binding, endpointAddress, instanceContext);
+        }
+
         public void SetEndpoint(ServiceEndpoint endpoint)
         {
             channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(endpoint);
+        }
+
+        public void SetEndpoint(ServiceEndpoint endpoint, object callbackObject)
+        {
+            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(endpoint, callbackObject);
+        }
+
+        public void SetEndpoint(ServiceEndpoint endpoint, InstanceContext instanceContext)
+        {
+            channelFactory = ChannelFactoryProvider.GetChannelFactory<TServiceInterface>(endpoint, instanceContext);
         }
 
         public void MaximumRetries(int retryCount)

--- a/source/WcfClientProxyGenerator/WcfClientProxyGenerator.csproj
+++ b/source/WcfClientProxyGenerator/WcfClientProxyGenerator.csproj
@@ -58,6 +58,7 @@
     <Compile Include="DefaultProxyConfigurator.cs" />
     <Compile Include="IActionInvoker.cs" />
     <Compile Include="IActionInvokerProvider.cs" />
+    <Compile Include="InstanceContext.cs" />
     <Compile Include="InvokeInfo.cs" />
     <Compile Include="IProxyConfigurator.cs" />
     <Compile Include="OnCallBeginHandler.cs" />


### PR DESCRIPTION
I've extended the API for working with instance contexts to have more control on client side. 

I also added the documentation part for wokring with duplex contract.


