### PR TITLE
Load <identity> element from app.config

### DIFF
--- a/source/WcfClientProxyGenerator.Tests/App.config
+++ b/source/WcfClientProxyGenerator.Tests/App.config
@@ -35,6 +35,57 @@
                 behaviorConfiguration="webHttp"
                 contract="WcfClientProxyGenerator.Tests.Infrastructure.ITestService"
                 name="BehaviorService" />
+
+      <endpoint address="http://localhost:23456/TestService_SpnIdentity"
+                binding="wsHttpBinding"
+                contract="WcfClientProxyGenerator.Tests.Infrastructure.ITestService"
+                name="TestService_SpnIdentity">
+        <identity>
+          <servicePrincipalName value="Service/host:40000" />
+        </identity>
+      </endpoint>
+
+      <endpoint address="http://localhost:23456/TestService_DnsIdentity"
+                binding="wsHttpBinding"
+                contract="WcfClientProxyGenerator.Tests.Infrastructure.ITestService"
+                name="TestService_DnsIdentity">
+        <identity>
+          <dns value="server" />
+        </identity>
+      </endpoint>
+
+      <endpoint address="http://localhost:23456/TestService_UpnIdentity"
+                binding="wsHttpBinding"
+                contract="WcfClientProxyGenerator.Tests.Infrastructure.ITestService"
+                name="TestService_UpnIdentity">
+        <identity>
+          <userPrincipalName value="someone@cohowinery.com" />
+        </identity>
+      </endpoint>
+
+      <endpoint address="http://localhost:23456/TestService_CertificateIdentity"
+                binding="wsHttpBinding"
+                contract="WcfClientProxyGenerator.Tests.Infrastructure.ITestService"
+                name="TestService_CertificateIdentity">
+        <identity>
+          <certificate
+            encodedValue="MIICwjCCAaoCCQD1vwyUDcjKBzANBgkqhkiG9w0BAQUFADAjMSEwHwYDVQQDDBhO
+VklESUEgR2FtZVN0cmVhbSBTZXJ2ZXIwHhcNMTYwNjI3MDYyODU4WhcNMzYwNjI3
+MDYyODU4WjAjMSEwHwYDVQQDDBhOVklESUEgR2FtZVN0cmVhbSBTZXJ2ZXIwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCbLT8/6UGCRHPwwNZGY9F5bcSr
+zGzsuvDZqj6v4wmcCT9pARZJQzKomtlz5/5+xSgSMNG5Q8a0MAh77+VJ6afhzuNi
+EV7zJw3YNvLn6u+WKAv9K9ZC9K5XPYUo1u4jwhcWru6SfCdVt0/V06qNhbiukLIl
+nGJb65R6wXD9F47r/eLYwVEUO70cmh/Lxi8sGzlGMCej+X4me/kNV7+bt95is5LN
+IUADBvk5s/H1B2qK0bDNaGZY4txnpxbL5562Ts7D6vZv1n2g6mWRo1aZnrkot5F/
+SwO1oCfnYz4Fv7SgEoDfyxucS4HsRLDU4eT0H9ugYrRR10u9FN4QXeURSRpfAgMB
+AAEwDQYJKoZIhvcNAQEFBQADggEBABFeCjuvgsW13x/kTTaznX+d/9egZivuQN1r
+rqgC+WwinOvUSy5vuPQymj08GlgkyqVfkg0GmZYYTDXhJs7O0wFoDBEJ+iGHb0dc
+o6RasEmoTIX5NyjtN+M8caGYwTOwwOTNWy3MxsQjUyQPgwv480lg7xoOx2MaOF0z
+si3SqRTb3dq+xiX+/PRYxSbixWwBvYMOn+2YlfGiow5A9VMrnz6aizXHrk3wH398
+usEXhLnvoGj2u5FlBYvtT3VcDmU/X5ahF8VmZs2cHCPspGZaF7y1X/w5pEmm2gyV
+EZpzM8SCE66uvJ7Cm/FDm6P2dWzzyGmC/xdKbxsTna/U8ezXrdo=" />
+        </identity>
+      </endpoint>
     </client>
   </system.serviceModel>
 </configuration>

--- a/source/WcfClientProxyGenerator.Tests/ChannelFactoryProviderTests.cs
+++ b/source/WcfClientProxyGenerator.Tests/ChannelFactoryProviderTests.cs
@@ -121,6 +121,50 @@ namespace WcfClientProxyGenerator.Tests
         }
 
         [Test]
+        public void ChannelFactory_Identity_WithSpnIdentity()
+        {
+            var factory = ChannelFactoryProvider.GetChannelFactory<ITestService>("TestService_SpnIdentity");
+
+            Assert.That(factory.Endpoint.Address.Identity, Is.TypeOf<SpnEndpointIdentity>());
+
+            var spnValue = factory.Endpoint.Address.Identity.IdentityClaim;
+            Assert.That(spnValue.Resource, Is.EqualTo("Service/host:40000"));
+        }
+
+        [Test]
+        public void ChannelFactory_Identity_WithDnsIdentity()
+        {
+            var factory = ChannelFactoryProvider.GetChannelFactory<ITestService>("TestService_DnsIdentity");
+
+            Assert.That(factory.Endpoint.Address.Identity, Is.TypeOf<DnsEndpointIdentity>());
+
+            var dnsValue = factory.Endpoint.Address.Identity.IdentityClaim;
+            Assert.That(dnsValue.Resource, Is.EqualTo("server"));
+        }
+
+        [Test]
+        public void ChannelFactory_Identity_WithUpnIdentity()
+        {
+            var factory = ChannelFactoryProvider.GetChannelFactory<ITestService>("TestService_UpnIdentity");
+
+            Assert.That(factory.Endpoint.Address.Identity, Is.TypeOf<UpnEndpointIdentity>());
+
+            var dnsValue = factory.Endpoint.Address.Identity.IdentityClaim;
+            Assert.That(dnsValue.Resource, Is.EqualTo("someone@cohowinery.com"));
+        }
+
+        [Test]
+        public void ChannelFactory_Identity_WithCertificateIdentity()
+        {
+            var factory = ChannelFactoryProvider.GetChannelFactory<ITestService>("TestService_CertificateIdentity");
+
+            Assert.That(factory.Endpoint.Address.Identity, Is.TypeOf<X509CertificateEndpointIdentity>());
+
+            var certificate = ((X509CertificateEndpointIdentity)factory.Endpoint.Address.Identity).Certificates[0];
+            Assert.That(certificate.SubjectName.Name, Is.EqualTo("CN=NVIDIA GameStream Server"));
+        }
+
+        [Test]
         public void NoConfigurationForServiceType_ThrowsInvalidOperationException()
         {
             Assert.That(() => ChannelFactoryProvider.GetChannelFactory<IAsyncTestInterface>(), Throws.TypeOf<InvalidOperationException>());

--- a/source/WcfClientProxyGenerator.Tests/WcfClientProxyGenerator.Tests.csproj
+++ b/source/WcfClientProxyGenerator.Tests/WcfClientProxyGenerator.Tests.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
@@ -99,6 +100,9 @@
       <Project>{56614d90-9eea-4908-8beb-7cd6e35bfcb0}</Project>
       <Name>WcfClientProxyGenerator</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
WcfClientProxyGenerator in current version seems to ignore `<identity>` under `<endpoint>` tag in app.config.
We need to use it along with windows authentication.

This pull request adds loading of `<identity>` tag during the creation of a proxy.
There is no test for a rsa identity as I could not find an example how to specify it. The example from official documentation seems to not work results in an exception even when using it without a library.